### PR TITLE
Fix SecurityController callback reference (v0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.2.1] - 2025-08-04
+
+- Fix SecurityController callback reference from :authenticate_api_keys_user! to :authenticate_api_keys_owner!
+- Resolves ArgumentError in production environments with eager loading (#2)
+
 ## [0.2.0] - 2025-06-03
 
 - Make gem owner-agnostic: API keys can now belong to any model (User, Organization, Team, etc.)

--- a/lib/api_keys/version.rb
+++ b/lib/api_keys/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ApiKeys
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
Fixes ArgumentError in production environments with eager loading

## Problem
SecurityController was calling `skip_before_action :authenticate_api_keys_user!` but the actual callback defined in ApplicationController is `:authenticate_api_keys_owner!`

## Solution
Fixed the callback reference to use the correct method name, aligning with the gem's owner-agnostic design.

## Changes
- Bump version to 0.2.1
- Update CHANGELOG.md with fix details

Closes #2

Generated with [Claude Code](https://claude.ai/code)