### PR TITLE
Fix blank scopes bypass in key_types mode

### DIFF
--- a/lib/api_keys/models/api_key.rb
+++ b/lib/api_keys/models/api_key.rb
@@ -184,13 +184,23 @@ module ApiKeys
     end
 
     # Basic scope check. Assumes scopes are stored as an array of strings.
-    # Returns true if the key has no specific scopes (allowing all) or includes the required scope.
+    #
+    # Behavior depends on whether key_types mode is enabled:
+    # - Simple mode (no key_types): blank scopes means "unrestricted" (all scopes allowed).
+    #   This preserves backwards compatibility for apps that don't use scopes at all.
+    # - Key types mode: blank scopes means "no permissions". When you've configured
+    #   key types with permission ceilings, an empty scope list should deny access,
+    #   not silently bypass the entire permission system.
     def allows_scope?(required_scope)
-      # Type casting for scopes/metadata happens via the attribute definition in the engine.
-      # Ensure the attribute is loaded/defined before using it.
-      # Check if the attribute method exists before calling .blank? or .include?
       return true unless respond_to?(:scopes) # Guard clause if loaded before attribute definition
-      scopes.blank? || scopes.include?(required_scope.to_s)
+
+      if scopes.blank?
+        # In key_types mode, blank scopes = no access (deny by default)
+        # In simple mode, blank scopes = unrestricted (allow by default)
+        return !ApiKeys.configuration.key_types.present?
+      end
+
+      scopes.include?(required_scope.to_s)
     end
 
     # Alias for scopes - provides a more user-friendly API that matches

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -45,6 +45,29 @@ module ApiKeys
         assert_not api_key.allows_scope?("admin")
       end
 
+      test "allows_scope? with blank scopes in simple mode allows all" do
+        # In simple mode (no key_types configured), blank scopes = unrestricted
+        api_key = ApiKeys::ApiKey.create!(owner: @user, name: "No Scopes", scopes: [])
+        assert api_key.allows_scope?("read")
+        assert api_key.allows_scope?("admin")
+        assert api_key.allows_scope?("anything")
+      end
+
+      test "allows_scope? with blank scopes in key_types mode denies all" do
+        # In key_types mode, blank scopes = no permissions
+        original_key_types = ApiKeys.configuration.key_types
+        ApiKeys.configuration.key_types = {
+          publishable: { prefix: "pk", permissions: %w[read] },
+          secret: { prefix: "sk", permissions: :all }
+        }
+
+        api_key = ApiKeys::ApiKey.create!(owner: @user, name: "Empty Scopes", scopes: [])
+        assert_not api_key.allows_scope?("read")
+        assert_not api_key.allows_scope?("admin")
+      ensure
+        ApiKeys.configuration.key_types = original_key_types
+      end
+
       test "creates with sha256 digest by default" do
         api_key = ApiKeys::ApiKey.create!(owner: @user, name: "SHA256 Default")
         assert_equal "sha256", api_key.digest_algorithm


### PR DESCRIPTION
## Summary
- `allows_scope?` previously treated blank/empty scopes as "unrestricted", granting access to all operations
- This is correct in **simple mode** (no `key_types` configured) where scopes are opt-in
- But in **key_types mode**, blank scopes silently bypass the entire permission ceiling system — a key with `scopes: []` could create licenses, revoke licenses, etc. regardless of its key type
- Now: blank scopes = "no access" when `key_types` is configured, "unrestricted" when it's not

## Test plan
- [x] New test: blank scopes in simple mode still allows all (backwards compatible)
- [x] New test: blank scopes in key_types mode denies all
- [x] Full test suite passes (216 runs, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)