### PR TITLE
Run required tests for every pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,15 +5,9 @@ permissions:
 
 on:
   pull_request:
-    paths-ignore:
-      - "*.md"
-      - "LICENSE.txt"
   push:
     branches:
       - main
-    paths-ignore:
-      - "*.md"
-      - "LICENSE.txt"
 
 jobs:
   test:


### PR DESCRIPTION
GitHub leaves required checks pending when an entire workflow is skipped by a path filter. Run the test matrix for every pull request so the upcoming main-branch ruleset cannot deadlock Markdown-only changes.

Validated with actionlint and YAML parsing.