### PR TITLE
Clean generated migrations and future-proof coverage

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,17 +1,18 @@
 # frozen_string_literal: true
 
-# SimpleCov configuration file (auto-loaded before test suite)
-# This keeps test_helper.rb clean and follows best practices
+# SimpleCov configuration file (auto-loaded before test suite).
+# Starting coverage and reporting live in test_helper.rb so this file remains
+# configuration-only, as required by current SimpleCov versions.
 
-SimpleCov.start do
+SimpleCov.configure do
   # Use SimpleFormatter for terminal-only output (no HTML generation)
   formatter SimpleCov::Formatter::SimpleFormatter
 
   # Track coverage for the lib directory (gem source code)
-  add_filter "/test/"
+  skip "/test/"
 
   # Track the lib and app directories
-  track_files "{lib,app}/**/*.rb"
+  cover "{lib,app}/**/*.rb"
 
   # Enable branch coverage for more detailed metrics
   enable_coverage :branch
@@ -21,15 +22,4 @@ SimpleCov.start do
 
   # Disambiguate parallel test runs
   command_name "Job #{ENV['TEST_ENV_NUMBER']}" if ENV['TEST_ENV_NUMBER']
-end
-
-# Print coverage summary to terminal after tests complete
-SimpleCov.at_exit do
-  SimpleCov.result.format!
-  puts "\n" + "=" * 60
-  puts "COVERAGE SUMMARY"
-  puts "=" * 60
-  puts "Line Coverage:   #{SimpleCov.result.covered_percent.round(2)}%"
-  puts "Branch Coverage: #{SimpleCov.result.coverage_statistics[:branch]&.percent&.round(2) || 'N/A'}%"
-  puts "=" * 60
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [Unreleased]
 
+### Fixed
+
+- Stop generated install and authentication-index migrations from carrying an unreachable `migration_version` instance method; the generator already renders the Active Record version into each migration superclass.
+
+### Maintenance
+
+- Move SimpleCov startup/reporting into the test helper and replace deprecated filtering/tracking APIs so the enforced line and branch coverage gates remain compatible with future SimpleCov releases.
+
 ## [0.4.0] - 2026-08-09
 
 This security-focused release hardens authentication, authorization, credential handling, the self-serve dashboard, background jobs, configuration, dependencies, CI, and the release supply chain. Upgrading is strongly recommended. Existing installations must apply the authentication lookup migration before deploying this version.

--- a/lib/generators/api_keys/templates/add_authentication_index_to_api_keys.rb.erb
+++ b/lib/generators/api_keys/templates/add_authentication_index_to_api_keys.rb.erb
@@ -21,12 +21,4 @@ class AddAuthenticationIndexToApiKeys < ActiveRecord::Migration<%= migration_ver
     options[:algorithm] = :concurrently if connection.adapter_name.downcase.include?("postgres")
     remove_index :api_keys, **options
   end
-
-  private
-
-  def migration_version
-    major = ActiveRecord::VERSION::MAJOR
-    minor = ActiveRecord::VERSION::MINOR
-    major >= 5 ? "[#{major}.#{minor}]" : ""
-  end
 end

--- a/lib/generators/api_keys/templates/create_api_keys_table.rb.erb
+++ b/lib/generators/api_keys/templates/create_api_keys_table.rb.erb
@@ -94,15 +94,4 @@ class CreateApiKeysTable < ActiveRecord::Migration<%= migration_version %>
     # Fallback during initial setup or if connection isn't available
     :text
   end
-
-  # Provides the appropriate migration version syntax for the current Rails version.
-  def migration_version
-    major = ActiveRecord::VERSION::MAJOR
-    minor = ActiveRecord::VERSION::MINOR
-    if major >= 5
-      "[#{major}.#{minor}]"
-    else
-      ""
-    end
-  end
 end

--- a/test/generators/add_authentication_index_generator_test.rb
+++ b/test/generators/add_authentication_index_generator_test.rb
@@ -20,6 +20,7 @@ module ApiKeys
           assert_includes migration, "index_exists?(:api_keys, COLUMNS, name: INDEX_NAME)"
           assert_includes migration, "algorithm] = :concurrently"
           assert_includes migration, "disable_ddl_transaction!"
+          refute_includes migration, "def migration_version"
         end
       end
     end

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -19,6 +19,7 @@ module ApiKeys
           assert_includes migration, "[:owner_type, :owner_id, :key_type, :environment]"
           refute_match(/^\s*t\.index :owner_id\b/, migration)
           refute_match(/^\s*t\.index :owner_type\b/, migration)
+          refute_includes migration, "def migration_version"
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,18 @@
 # SimpleCov must be loaded BEFORE any application code
 # Configuration is auto-loaded from .simplecov file
 require "simplecov"
+SimpleCov.start
+
+# Print coverage summary to terminal after tests complete.
+SimpleCov.at_exit do
+  SimpleCov.result.format!
+  puts "\n" + "=" * 60
+  puts "COVERAGE SUMMARY"
+  puts "=" * 60
+  puts "Line Coverage:   #{SimpleCov.result.covered_percent.round(2)}%"
+  puts "Branch Coverage: #{SimpleCov.result.coverage_statistics[:branch]&.percent&.round(2) || 'N/A'}%"
+  puts "=" * 60
+end
 
 ENV["RAILS_ENV"] ||= "test"
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)


### PR DESCRIPTION
## Context

This is a follow-up to the adversarial v0.4.0 hardening and downstream adoption work recorded in #23 and issue #12. While applying v0.4.0 to real RailsFast applications, we audited whether any downstream discovery belonged in the gem itself rather than being left as application-local knowledge.

This PR contains the one gem-level generator-quality finding from that pass and a test-infrastructure compatibility issue exposed while validating it. It does **not** alter authentication, authorization, key material, persistence, cache, migration schema, or any v0.4.0 runtime security control.

## Findings and fixes

### Generated migrations contained dead generator helpers

Both `create_api_keys_table.rb.erb` and `add_authentication_index_to_api_keys.rb.erb` correctly interpolate `migration_version` while the Rails generator renders the ERB superclass. They also emitted a second `migration_version` instance method into the generated migration.

That emitted method was unreachable: Active Record has already parsed the rendered superclass version before a migration instance exists, and no generated migration code calls the method. It was harmless, but it gave every new installation and every v0.4.0 authentication-index upgrade misleading dead code to own forever.

This PR removes the emitted methods while retaining the generator-side helpers that perform the actual ERB interpolation. Regression assertions now prove neither generated migration contains `def migration_version`.

Existing generated migrations remain valid and require no edit, rollback, rerun, data change, key rotation, or production deployment. This is output hygiene for future generator runs.

### SimpleCov was using APIs scheduled for removal

The focused generator test passed its assertions, but SimpleCov warned that:

- calling `SimpleCov.start` from `.simplecov` will stop being supported;
- `add_filter` is deprecated in favor of `skip`;
- `track_files` is deprecated in favor of `cover`.

Coverage configuration now remains in `.simplecov`, startup/reporting happens in `test/test_helper.rb` before application code loads, and the current `skip`/`cover` APIs preserve the existing enforced 80% line / 75% branch floors.

The apparent non-zero result from an isolated test-file run was only the repository-wide coverage gate doing its job: one generator file cannot cover the whole gem. The canonical full suite is the authoritative validation and passes above both floors.

## Validation

- `bundle exec rake test`: **315 tests, 970 assertions, 0 failures, 0 errors, 0 skips**
- Coverage: **86.61% line, 77.14% branch**
- No SimpleCov deprecation warnings after the change
- Main dependency audit: no vulnerabilities
- Dummy-app lockfile audit: no vulnerabilities
- Docker dummy-app lockfile audit: no vulnerabilities
- Brakeman against the engine/demo: **0 warnings**
- `git diff --check`: clean
- The repository does not bundle RuboCop, so `bundle exec rubocop` is not a valid project gate. A globally installed RuboCop was intentionally not used as an authority because it applies unrelated defaults, cannot correctly parse ERB migration templates as plain Ruby, and reports pre-existing style choices throughout the test helper.

GitHub CI remains the cross-version authority and will exercise Ruby 3.3/3.4/4.0 against Rails 7.2/8.0/8.1, plus the security and CodeQL workflows.

## Release and upgrade impact

- v0.4.0 remains the current production hardening release and fully resolves/supersedes issue #12.
- This maintenance fix lands after v0.4.0 and will be included in the next gem release; it does not justify an emergency release because installed v0.4.0 runtime code and generated schemas are unaffected.
- No downstream action is required. Applications that have not yet adopted v0.4.0 must still run `rails generate api_keys:add_authentication_index` and migrate before deploying v0.4.0, as documented in #23 and the v0.4.0 release notes.

## Durable handoff notes

- The RailsFast Base template does not currently install `api_keys`; it contains only a commented opt-in Gemfile line and commented route, so no base-template dependency pin or API-key migration belongs there.
- Real downstream consumers were updated separately in `rameerez/licenseseat#45` and `rameerez/vehiclesdb-web#9`; both are merged and their post-merge main CI runs passed.
- The public `rameerez/vehiclesdb` dataset repository does not consume the gem and was not changed.
- Application-specific findings were kept downstream: LicenseSeat's origin foreign-key deletion behavior and VehiclesDB Web's host helper/controller issues are not generic gem behavior.
- Reusable RailsFast CI, libvips, sanitizer, and Claude-review cleanup is being submitted to `railsfast/railsfast-base` separately and will be cross-linked after both PRs exist.
- Commits are SSH-signed with the maintainer key. GitHub may display `unknown_key` until that public key is registered separately as an account signing key; this is an account metadata issue, not missing commit signature data.

## Related records

- Canonical v0.4.0 hardening record: #23
- Original hardening checklist/disposition: #12
- Release: https://github.com/rameerez/api_keys/releases/tag/v0.4.0
- LicenseSeat adoption: https://github.com/rameerez/licenseseat/pull/45
- VehiclesDB Web adoption: https://github.com/rameerez/vehiclesdb-web/pull/9
